### PR TITLE
Do not compress within aiohttp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   global:
     - PIP_DOWNLOAD_CACHE=".pip_download_cache"
 python:
-  - "3.3"
   - "3.4"
+  - "3.5"
 install:
   - time make
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
     - PIP_DOWNLOAD_CACHE=".pip_download_cache"
 python:
   - "3.4"
-  - "3.5"
 install:
   - time make
 script:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A transport for [raven-python](https://github.com/getsentry/raven-python) which 
 
 - `raven-python>=5.4.0`
 - `python>=3.3`
-- `aiohttp`
+- `aiohttp>=0.19`
 
 ## Usage
 

--- a/raven_aiohttp.py
+++ b/raven_aiohttp.py
@@ -39,7 +39,7 @@ class AioHttpTransport(AsyncTransport, HTTPTransport):
             try:
                 resp = yield from asyncio.wait_for(
                     aiohttp.request('POST',
-                                    self._url, data=data,
+                                    self._url, data=data, compress=False,
                                     headers=headers,
                                     connector=self._connector,
                                     loop=self._loop),

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ tests_require = [
 
 
 install_requires = [
-    'aiohttp',
+    'aiohttp>=0.19',
     'raven>=5.4.0',
 ]
 


### PR DESCRIPTION
I came accross the same issue as https://github.com/getsentry/raven-aiohttp/issues/4, and figured out that @mwfrojdman has fixed the problem upstream, in https://github.com/KeepSafe/aiohttp/pull/621, which is now in release 0.19.

I'm not sure if we should always ask for no compression, maybe we should check content encoding ? I don't know about Raven's internals.
