### PR TITLE
Capitalize acronyms in camelcase names

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ After installing the package, configure the client with the transport:
 
 ```
 from raven import Client
-from raven_aiohttp import AioHttpTransport
+from raven_aiohttp import AIOHTTPTransport
 
-client = Client(transport=AioHttpTransport)
+client = Client(transport=AIOHTTPTransport)
 ```

--- a/raven_aiohttp.py
+++ b/raven_aiohttp.py
@@ -20,7 +20,7 @@ except ImportError:
     ensure_future = asyncio.async
 
 
-class AioHttpTransport(AsyncTransport, HTTPTransport):
+class AIOHTTPTransport(AsyncTransport, HTTPTransport):
     def __init__(self, parsed_url, *, verify_ssl=True, resolve=True,
                  timeout=defaults.TIMEOUT,
                  keepalive=True, family=socket.AF_INET, loop=None):

--- a/test_raven_aiohttp.py
+++ b/test_raven_aiohttp.py
@@ -1,10 +1,10 @@
 from raven import Client
-from raven_aiohttp import AioHttpTransport
+from raven_aiohttp import AIOHTTPTransport
 
 
 def test_simple():
     client = Client('http://public:secret@example.com/1',
-                    transport=AioHttpTransport)
+                    transport=AIOHTTPTransport)
     assert client.is_enabled()
     # TODO(dcrmer): figure out how to actually test this
     # assert client.captureMessage('test')


### PR DESCRIPTION
In order to be consistent with raven-python, e.g. `HTTPTransport`.
