### PR TITLE
Proxy support

### DIFF
--- a/raven_aiohttp.py
+++ b/raven_aiohttp.py
@@ -36,13 +36,16 @@ class AioHttpTransportBase(
 
     def __init__(self, parsed_url=None, *, verify_ssl=True,
                  timeout=defaults.TIMEOUT,
-                 keepalive=True, family=socket.AF_INET, loop=None):
+                 keepalive=True, family=socket.AF_INET, loop=None,
+                 proxy=None, proxy_auth=None):
         self._keepalive = keepalive
         self._family = family
         if loop is None:
             loop = asyncio.get_event_loop()
 
         self._loop = loop
+        self._proxy = proxy
+        self._proxy_auth = proxy_auth
 
         if has_newstyle_transports:
             if parsed_url is not None:
@@ -87,6 +90,8 @@ class AioHttpTransportBase(
                 data=data,
                 compress=False,
                 headers=headers,
+                proxy=self._proxy,
+                proxy_auth=self._proxy_auth,
                 timeout=self.timeout
             )
 


### PR DESCRIPTION
As aiohttp won't support setting up proxy from environment variables (https://github.com/aio-libs/aiohttp/issues/529), I've had to implement it as a transport option.

Example usage:

```sentry_dsn = "https://public_key:private_key@sentry.io/1234?proxy=http%3A%2F%2Fproxy%3A3128"```