### PR TITLE
Fix supported Python versions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Requirements
 ============
 
 - `raven-python>=5.4.0`
-- `python>=3.3`
+- `python>=3.4.2`
 - `aiohttp>=2.0`
 
 Usage

--- a/raven_aiohttp.py
+++ b/raven_aiohttp.py
@@ -122,12 +122,12 @@ class AioHttpTransportBase(
                 yield from session.close()
 
     @abc.abstractmethod
-    def _async_send(self, *, timeout=None):  # pragma: no cover
+    def _async_send(self, url, data, headers, success_cb, failure_cb):  # pragma: no cover
         pass
 
     @abc.abstractmethod
     @asyncio.coroutine
-    def _close(self, *, timeout=None):  # pragma: no cover
+    def _close(self):  # pragma: no cover
         pass
 
     def async_send(self, url, data, headers, success_cb, failure_cb):

--- a/raven_aiohttp.py
+++ b/raven_aiohttp.py
@@ -183,7 +183,7 @@ class AioHttpTransport(AioHttpTransportBase):
         task.add_done_callback(self._tasks.remove)
 
     @asyncio.coroutine
-    def _close(self, timeout=None):
+    def _close(self):
         yield from asyncio.gather(
             *self._tasks,
             return_exceptions=True,

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/blob/master/setup.py#L110

Python 3.3 is no supported by aiohttp