### PR TITLE
Fix raven package name in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ and other goodies.
 Requirements
 ============
 
-- `raven-python>=5.4.0`
+- `raven>=5.4.0`
 - `python>=3.4.2`
 - `aiohttp>=2.0`
 


### PR DESCRIPTION
Although the github project is called "raven-python", the PyPI package
is called "raven".